### PR TITLE
feat(skills): add skills section to portfolio

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "vmg-portfolio",
       "version": "0.0.0",
       "dependencies": {
+        "@iconify/react": "^6.0.0",
         "i18next": "^25.0.2",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
@@ -1248,6 +1249,27 @@
         "type": "github",
         "url": "https://github.com/sponsors/nzakas"
       }
+    },
+    "node_modules/@iconify/react": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@iconify/react/-/react-6.0.0.tgz",
+      "integrity": "sha512-eqNscABVZS8eCpZLU/L5F5UokMS9mnCf56iS1nM9YYHdH8ZxqZL9zyjSwW60IOQFsXZkilbBiv+1paMXBhSQnw==",
+      "license": "MIT",
+      "dependencies": {
+        "@iconify/types": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/cyberalien"
+      },
+      "peerDependencies": {
+        "react": ">=16"
+      }
+    },
+    "node_modules/@iconify/types": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@iconify/types/-/types-2.0.0.tgz",
+      "integrity": "sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==",
+      "license": "MIT"
     },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "test": "jest"
   },
   "dependencies": {
+    "@iconify/react": "^6.0.0",
     "i18next": "^25.0.2",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import Header from './components/Header'
 import AboutMe from './sections/AboutMe/AboutMe'
 import Hero from './sections/Hero/Hero'
 import Projects from './sections/Projects/Projects'
+import Skills from './sections/Skills/Skills'
 
 function App() {
   return (
@@ -12,6 +13,7 @@ function App() {
       <Hero />
       <AboutMe />
       <Projects />
+      <Skills />
       <Footer />
     </>
   )

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -23,6 +23,9 @@ export const en = {
     },
     buttonText: 'View'
   },
+  skills: {
+    title: "Skills",
+  },
   footer: {
     rights: "Viviana Moreno. All rights reserved.",
   }

--- a/src/i18n/es.ts
+++ b/src/i18n/es.ts
@@ -23,6 +23,9 @@ export const es = {
     },
     buttonText: 'Ver'
   },
+  skills: {
+    title: "Habilidades",
+  },
   footer: {
     rights: "Viviana Moreno. Todos los derechos reservados.",
   }

--- a/src/sections/Skills/SkillCard.tsx
+++ b/src/sections/Skills/SkillCard.tsx
@@ -1,0 +1,14 @@
+import { Icon } from '@iconify/react';
+import { Skill } from '../../types/Skill.type';
+
+export default function SkillCard({ name, icon }: Skill) {
+  return (
+    <div
+      className="flex flex-col items-center justify-center p-4 border rounded-xl shadow-sm hover:shadow-md transition bg-white dark:bg-gray-700"
+      aria-label={name}
+    >
+      <Icon icon={icon} width="40" height="40" />
+      <span className="mt-2 text-sm text-gray-700 dark:text-gray-200">{name}</span>
+    </div>
+  );
+}

--- a/src/sections/Skills/Skills.tsx
+++ b/src/sections/Skills/Skills.tsx
@@ -1,0 +1,30 @@
+import { useTranslation } from "react-i18next";
+import SkillCard from "./SkillCard";
+import { skills } from "../../utils/skillsData";
+
+export default function SkillsSection() {
+  const { t } = useTranslation();
+  return (
+    <section className="py-16 px-6 md:px-24 bg-white">
+      <h2 className="text-3xl font-bold text-purple-700 mb-10">
+        { t('skills.title')}
+      </h2>
+
+      <div className="space-y-12">
+        {Object.entries(skills).map(([category, items]) => (
+          <div key={category}>
+            <h3 className="text-2xl font-semibold mb-6 text-gray-700 dark:text-gray-300">
+              {category}
+            </h3>
+
+            <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-6">
+              {items.map((skill) => (
+                <SkillCard key={skill.name} {...skill} />
+              ))}
+            </div>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/src/types/Skill.type.ts
+++ b/src/types/Skill.type.ts
@@ -1,0 +1,8 @@
+export interface Skill {
+  name: string;
+  icon: string;
+}
+
+export interface SkillsCategory {
+  [category: string]: Skill[];
+}

--- a/src/utils/skillsData.ts
+++ b/src/utils/skillsData.ts
@@ -1,0 +1,41 @@
+import { SkillsCategory } from "../types/Skill.type";
+
+export const skills: SkillsCategory = {
+  Frontend: [
+    { name: 'HTML', icon: 'vscode-icons:file-type-html' },
+    { name: 'CSS', icon: 'vscode-icons:file-type-css' },
+    { name: 'SCSS', icon: 'vscode-icons:file-type-scss2' },
+    { name: 'JavaScript', icon: 'vscode-icons:file-type-js-official' },
+    { name: 'TypeScript', icon: 'vscode-icons:file-type-typescript-official' },
+    { name: 'ReactJS', icon: 'logos:react' },
+    { name: 'React Native', icon: 'logos:react' },
+    { name: 'Angular 7+', icon: 'logos:angular-icon' },
+    { name: 'TailwindCSS', icon: 'vscode-icons:file-type-tailwind' },
+    { name: 'Figma', icon: 'logos:figma' },
+  ],
+  Backend: [
+    { name: 'NestJS', icon: 'simple-icons:nestjs' },
+    { name: 'Spring Boot', icon: 'simple-icons:springboot' },
+    { name: 'Firebase', icon: 'logos:firebase' },
+    { name: 'RESTful APIs', icon: 'carbon:api' },
+  ],
+  Databases: [
+    { name: 'MongoDB', icon: 'logos:mongodb-icon' },
+    { name: 'MySQL', icon: 'logos:mysql-icon' },
+  ],
+  Testing: [
+    { name: 'Jest', icon: 'logos:jest' },
+    { name: 'Postman', icon: 'logos:postman-icon' },
+    { name: 'Swagger', icon: 'logos:swagger' },
+    { name: 'SoapUI', icon: 'simple-icons:soapui' },
+  ],
+  DevTools: [
+    { name: 'Git', icon: 'logos:git-icon' },
+    { name: 'GitHub', icon: 'mdi:github' },
+    { name: 'Azure DevOps', icon: 'logos:azure-devops' },
+  ],
+  IDEs: [
+    { name: 'Xcode', icon: 'logos:xcode' },
+    { name: 'Android Studio', icon: 'logos:android-studio' },
+  ],
+};


### PR DESCRIPTION
This PR introduces the new "Skills" section to the portfolio.

- Categorized skills: Frontend, Backend, Databases, Testing, DevTools, IDEs  
- Integrated @iconify/react for skill icons  
- Modular structure following best practices  
- Responsive design with TailwindCSS  
- Dark mode compatibility